### PR TITLE
Adjust script for current export format of Runtastic

### DIFF
--- a/runtastic-gpx-converter.py
+++ b/runtastic-gpx-converter.py
@@ -5,7 +5,7 @@ import json
 import xml.etree.ElementTree as ET
 import datetime
 
-usage_message = 'RUNTASTIC-GPX-CONVERTER: bad command line'
+usage_message = 'Usage: python runtastic-gpx-converter.py <path_to_runtastic_export_zip>'
 started_message = 'conversion started, please wait ...'
 success_message = 'conversion completed'
 


### PR DESCRIPTION
Apparently, Runtastic changed some things about their data export:
* timestamps are all supplied as utc timestamps with milliseconds
* `distance` is now a nested attribute for each sport session. It occurs multiple times under `track_metrics` and `initial_values`. I've decided to just use `track_metrics.distance` in this case.
* `gpx` and `json` files in `Sport-sessions/GPS-data` required me to adjust the listing of all activities by filtering for `json` files only