### PR TITLE
Support newer adidas exports and add TCX output for Garmin Connect (May 2026)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # runtastic-gpx-converter
 
-This Python script converts Adidas Running (formerly Runtastic) account data exports to GPX format, ready to be imported into Garmin Connect.
+This Python script converts Adidas Running (formerly Runtastic) account data exports to Garmin-friendly activity archives.
+
+It supports older and newer adidas exports, including exports that:
+
+- store GPS timestamps as Unix milliseconds instead of formatted strings
+- omit `Sport-sessions/Elevation-data`
+- include pre-generated GPX files next to the GPS JSON payload
+- keep distance inside nested `features` objects instead of a top-level field
+
+The converter generates both:
+
+- `*_GPX.zip`: preserves the source GPX activity type where available
+- `*_TCX.zip`: better suited for Garmin Connect imports because TCX carries an explicit sport field (`Running`, `Biking`, or `Other`)
 
 ## Instructions
 
@@ -10,6 +22,12 @@ This Python script converts Adidas Running (formerly Runtastic) account data exp
 ```sh
 > py runtastic-gpx-converter.py YOUR-ACCOUNT-DATA.zip
 ```
-  this command will create a new ZIP file in the same folder as the original with all your account data converted to GPX format
 
-3. Import your fitness data in GPX format into Garmin Connect, as shown [here](https://support.garmin.com/en-IE/?faq=ACgfZF717vAeVfhHgPrFv6)
+This command will create two new ZIP files in the same folder as the original export:
+
+- `YOUR-ACCOUNT-DATA_GPX.zip`
+- `YOUR-ACCOUNT-DATA_TCX.zip`
+
+3. Import your fitness data into Garmin Connect, as shown [here](https://support.garmin.com/en-IE/?faq=ACgfZF717vAeVfhHgPrFv6)
+
+If Garmin Connect classifies GPX uploads as `Other`, prefer the generated TCX archive. Garmin Connect generally respects the TCX sport field for `Running` and `Biking`.

--- a/runtastic-gpx-converter.py
+++ b/runtastic-gpx-converter.py
@@ -20,7 +20,10 @@ SOURCE_TYPE_TO_TCX_SPORT = {
     "cycling": "Biking",
 }
 
-# Fallback only when adidas does not provide a source GPX file with a type.
+# Fallback mapping for known adidas/runtastic sport_type_id values.
+# Prefer the activity type from the source GPX when it is available, because
+# that is the most precise type bundled with the export. This table is only
+# used when a readable source GPX type is missing.
 SPORT_TYPE_ID_TO_SOURCE_TYPE = {
     "1": "running",
     "3": "cycling",

--- a/runtastic-gpx-converter.py
+++ b/runtastic-gpx-converter.py
@@ -1,200 +1,340 @@
-import sys
-import zipfile
-import os.path
-import json
-import xml.etree.ElementTree as ET
 import datetime
+import json
+import os.path
+import sys
+import xml.etree.ElementTree as ET
+import zipfile
 
-usage_message = 'RUNTASTIC-GPX-CONVERTER: bad command line'
-started_message = 'conversion started, please wait ...'
-success_message = 'conversion completed'
+USAGE_MESSAGE = "RUNTASTIC-GPX-CONVERTER: bad command line"
+STARTED_MESSAGE = "conversion started, please wait ..."
+SUCCESS_MESSAGE = "conversion completed"
 
-class Node:
-    def __init__(self, data, left=None, right=None):
-        self.data = data
-        self.left = left
-        self.right = right
+GPX_NAMESPACE = {"gpx": "http://www.topografix.com/GPX/1/1"}
+TCX_NAMESPACE = "http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2"
+GPX_DIRECTORY = "Sport-sessions/GPS-data"
+ELEVATION_DIRECTORY = "Sport-sessions/Elevation-data"
+SESSION_DIRECTORY = "Sport-sessions"
 
-class BST:
-    def __init__(self, node=None, func=None):
-        self.root = node
-        self.func = func
+SOURCE_TYPE_TO_TCX_SPORT = {
+    "running": "Running",
+    "cycling": "Biking",
+}
 
-    def insert(self, data):
-        if self.root == None:
-            self.root = Node(data)
-        else:
-            node = self.root
-            parent = None
-            while node != None:
-                parent = node
-                if self.func != None:
-                    node = node.left if self.func(data, node.data) else node.right
-                else:
-                    node = node.left if data < node.data else node.right
-            if self.func != None:
-                if self.func(data, parent.data):
-                    parent.left = Node(data)
-                else:
-                    parent.right = Node(data)
-            else:
-                if data < parent.data:
-                    parent.left = Node(data)
-                else:
-                    parent.right = Node(data)
+# Fallback only when adidas does not provide a source GPX file with a type.
+SPORT_TYPE_ID_TO_SOURCE_TYPE = {
+    "1": "running",
+    "3": "cycling",
+    "7": "hiking",
+    "19": "strolling",
+    "44": "kayaking",
+    "54": "ice_skating",
+}
 
-def traversal(node):
-    if node != None:
-        yield from traversal(node.left)
-        yield node.data
-        yield from traversal(node.right)
 
-def transformdate(date):
-    # change date string into ISO format
-    date = date.split()
-    date = date[0] + 'T' + date[1] + date[2][0:3] + ':' + date[2][3:]
-    # build datetime object from ISO format
-    date = datetime.datetime.fromisoformat(date)
-    # change timezone from local to UTC
-    date = date.astimezone(datetime.timezone.utc)
-    # return updated date in ISO format
-    return date.isoformat(timespec='milliseconds')
-
-class activity:
+class Activity:
     def __init__(self):
         self.id = None
         self.datetime = None
-        self.distance = None # metres
-        self.duration = None # milliseconds
+        self.distance_km = None
+        self.distance_m = None
+        self.duration_display = None
+        self.duration_ms = None
+        self.calories = None
+        self.source_type = None
         self.gpx = None
+        self.tcx = None
 
-def getactivity(zip, basename):
-    # session data
-    sesdata = json.load(zip.open('Sport-sessions/' + basename, 'r'))
-    # gps data
-    gpsdata = json.load(zip.open('Sport-sessions/GPS-data/' + basename, 'r'))
-    # elevation data
-    eledata = json.load(zip.open('Sport-sessions/Elevation-data/' + basename, 'r'))
 
-    act = activity()
-    act.id = sesdata['id']
-    # act.datetime = gpsdata[0]['timestamp']
+def iter_sorted(items, key):
+    for item in sorted(items, key=key):
+        yield item
 
-    # change timestamp string into ISO format
-    timestamp = gpsdata[0]['timestamp'].split()
-    timestamp = timestamp[0] + 'T' + timestamp[1] + timestamp[2][0:3] + ':' + timestamp[2][3:]
-    # build datetime object from ISO format
-    act.datetime = datetime.datetime.fromisoformat(timestamp)
 
-    act.distance = '%.2f' % (sesdata['distance'] * 0.001) # from metres to kilometres
-    
-    SS = (sesdata['duration'] * 0.001) # from milliseconds to seconds
-    MM, SS = divmod(SS, 60)
-    HH, MM = divmod(MM, 60)
-    act.duration = '%02d:%02d:%02d' % (HH, MM, SS)  # from seconds to HH:MM:SS
-    
-    attr = {
-        'creator': 'Garmin Connect',
-        'version': '1.1',
-        'xsi:schemaLocation': 'http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/11.xsd',
-        'xmlns:ns3': 'http://www.garmin.com/xmlschemas/TrackPointExtension/v1',
-        'xmlns': 'http://www.topografix.com/GPX/1/1',
-        'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
-        'xmlns:ns2': 'http://www.garmin.com/xmlschemas/GpxExtensions/v3'
+def transformdate(value):
+    if isinstance(value, (int, float)):
+        return datetime.datetime.fromtimestamp(
+            value / 1000, tz=datetime.timezone.utc
+        ).isoformat(timespec="milliseconds")
+
+    parts = value.split()
+    iso_value = parts[0] + "T" + parts[1] + parts[2][0:3] + ":" + parts[2][3:]
+    parsed = datetime.datetime.fromisoformat(iso_value)
+    return parsed.astimezone(datetime.timezone.utc).isoformat(timespec="milliseconds")
+
+
+def getfeatureattributes(sessiondata, featuretype):
+    for feature in sessiondata.get("features", []):
+        if feature.get("type") == featuretype:
+            return feature.get("attributes", {})
+    return {}
+
+
+def readjsonfromzip(archive, path, default=None):
+    try:
+        with archive.open(path, "r") as handle:
+            return json.load(handle)
+    except KeyError:
+        return default
+
+
+def getdistance(sessiondata):
+    distance = sessiondata.get("distance")
+    if distance is not None:
+        return distance
+
+    distance = getfeatureattributes(sessiondata, "track_metrics").get("distance")
+    if distance is not None:
+        return distance
+
+    return getfeatureattributes(sessiondata, "initial_values").get("distance", 0)
+
+
+def getsourcetype(archive, basename, sessiondata):
+    source_gpx_path = os.path.join(
+        GPX_DIRECTORY, os.path.splitext(basename)[0] + ".gpx"
+    )
+
+    try:
+        source_xml = ET.fromstring(archive.read(source_gpx_path))
+        source_type = source_xml.find("./gpx:trk/gpx:type", GPX_NAMESPACE)
+        if source_type is not None and source_type.text:
+            return source_type.text
+    except (KeyError, ET.ParseError):
+        pass
+
+    return SPORT_TYPE_ID_TO_SOURCE_TYPE.get(sessiondata.get("sport_type_id"), "other")
+
+
+def gettcxsport(source_type):
+    return SOURCE_TYPE_TO_TCX_SPORT.get(source_type, "Other")
+
+
+def getactivitysummary(activity):
+    return [
+        activity.id,
+        activity.datetime.strftime("%d-%m-%Y %H:%M"),
+        activity.distance_km,
+        activity.duration_display,
+    ]
+
+
+def buildgpx(activity, gpsdata, eledata):
+    attributes = {
+        "creator": "Garmin Connect",
+        "version": "1.1",
+        "xsi:schemaLocation": (
+            "http://www.topografix.com/GPX/1/1 "
+            "http://www.topografix.com/GPX/1/1/gpx.xsd "
+            "http://www.garmin.com/xmlschemas/GpxExtensions/v3 "
+            "http://www.garmin.com/xmlschemas/GpxExtensionsv3.xsd "
+            "http://www.garmin.com/xmlschemas/TrackPointExtension/v1 "
+            "http://www.garmin.com/xmlschemas/TrackPointExtensionv1.xsd"
+        ),
+        "xmlns:gpxtpx": "http://www.garmin.com/xmlschemas/TrackPointExtension/v1",
+        "xmlns": "http://www.topografix.com/GPX/1/1",
+        "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+        "xmlns:gpxx": "http://www.garmin.com/xmlschemas/GpxExtensions/v3",
     }
 
-    gpx = ET.Element('gpx', attr)
+    gpx = ET.Element("gpx", attributes)
+    metadata = ET.SubElement(gpx, "metadata")
+    link = ET.SubElement(metadata, "link", {"href": "connect.garmin.com"})
+    link_text = ET.SubElement(link, "text")
+    link_text.text = "Garmin Connect"
+    metadata_time = ET.SubElement(metadata, "time")
+    metadata_time.text = transformdate(gpsdata[0]["timestamp"])
 
-    meta = ET.SubElement(gpx, 'metadata')
-    link = ET.SubElement(meta, 'link', {'href': 'connect.garmin.com'})
-    text = ET.Element('text')
-    text.text = 'Garmin Connect'
-    link.append(text)
-    time = ET.Element('time')
-    # change timezone from local to UTC and use ISO format
-    # time.text = act.datetime.astimezone(datetime.timezone.utc).isoformat(timespec='milliseconds')
-    time.text = transformdate(gpsdata[0]['timestamp'])
-    meta.append(time)
+    track = ET.SubElement(gpx, "trk")
+    track_name = ET.SubElement(track, "name")
+    track_name.text = activity.id
+    track_type = ET.SubElement(track, "type")
+    track_type.text = activity.source_type
+    track_segment = ET.SubElement(track, "trkseg")
 
-    trk = ET.SubElement(gpx, 'trk')
+    same_length = len(gpsdata) == len(eledata)
 
-    trkname = ET.Element('name')
-    trkname.text = act.id
-    trk.append(trkname)
-    trktype = ET.Element('type')
-    trktype.text = 'running' # sesdata['sport_type_id']
-    trk.append(trktype)
+    for index, point in enumerate(gpsdata):
+        track_point = ET.SubElement(
+            track_segment,
+            "trkpt",
+            {"lat": str(point["latitude"]), "lon": str(point["longitude"])},
+        )
 
-    trkseg = ET.SubElement(trk, 'trkseg')
-
-    samelen = (len(gpsdata) == len(eledata))
-
-    for i in range(len(gpsdata)):
-        lat = str(gpsdata[i]['latitude'])
-        lon = str(gpsdata[i]['longitude'])
-        trkpt = ET.SubElement(trkseg, 'trkpt', {'lat' : lat, 'lon': lon})
-
-        ele = ET.Element('ele')
-        if samelen and (gpsdata[i]['timestamp'] == eledata[i]['timestamp']):
-            ele.text = str(eledata[i]['elevation'])
+        elevation = ET.SubElement(track_point, "ele")
+        if same_length and point["timestamp"] == eledata[index]["timestamp"]:
+            elevation.text = str(eledata[index]["elevation"])
         else:
-            ele.text = str(gpsdata[i]['altitude'])
-        trkpt.append(ele)
+            elevation.text = str(point["altitude"])
 
-        time = ET.Element('time')
-        time.text = transformdate(gpsdata[i]['timestamp'])
-        trkpt.append(time)
+        point_time = ET.SubElement(track_point, "time")
+        point_time.text = transformdate(point["timestamp"])
 
-        exts = ET.SubElement(trkpt, 'extensions')
-        ET.SubElement(exts, 'ns3:TrackPointExtension')
+        extensions = ET.SubElement(track_point, "extensions")
+        ET.SubElement(extensions, "gpxtpx:TrackPointExtension")
 
-    act.gpx = ET.tostring(gpx, encoding="UTF-8")
+    return ET.tostring(gpx, encoding="UTF-8")
 
-    return act
+
+def buildtcx(activity, gpsdata, eledata):
+    attributes = {
+        "xmlns": TCX_NAMESPACE,
+        "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+        "xsi:schemaLocation": (
+            TCX_NAMESPACE
+            + " http://www.garmin.com/xmlschemas/TrainingCenterDatabasev2.xsd"
+        ),
+    }
+
+    tcx = ET.Element("TrainingCenterDatabase", attributes)
+    activities = ET.SubElement(tcx, "Activities")
+    tcx_activity = ET.SubElement(
+        activities, "Activity", {"Sport": gettcxsport(activity.source_type)}
+    )
+
+    activity_id = ET.SubElement(tcx_activity, "Id")
+    activity_id.text = transformdate(gpsdata[0]["timestamp"])
+
+    lap = ET.SubElement(
+        tcx_activity, "Lap", {"StartTime": transformdate(gpsdata[0]["timestamp"])}
+    )
+
+    total_time = ET.SubElement(lap, "TotalTimeSeconds")
+    total_time.text = "%.3f" % (activity.duration_ms * 0.001)
+
+    distance = ET.SubElement(lap, "DistanceMeters")
+    distance.text = str(activity.distance_m)
+
+    maximum_speed = ET.SubElement(lap, "MaximumSpeed")
+    maximum_speed.text = str(max(point.get("speed", 0) for point in gpsdata))
+
+    calories = ET.SubElement(lap, "Calories")
+    calories.text = str(activity.calories)
+
+    intensity = ET.SubElement(lap, "Intensity")
+    intensity.text = "Active"
+
+    trigger_method = ET.SubElement(lap, "TriggerMethod")
+    trigger_method.text = "Manual"
+
+    track = ET.SubElement(lap, "Track")
+    same_length = len(gpsdata) == len(eledata)
+
+    for index, point in enumerate(gpsdata):
+        trackpoint = ET.SubElement(track, "Trackpoint")
+
+        point_time = ET.SubElement(trackpoint, "Time")
+        point_time.text = transformdate(point["timestamp"])
+
+        position = ET.SubElement(trackpoint, "Position")
+        latitude = ET.SubElement(position, "LatitudeDegrees")
+        latitude.text = str(point["latitude"])
+        longitude = ET.SubElement(position, "LongitudeDegrees")
+        longitude.text = str(point["longitude"])
+
+        altitude = ET.SubElement(trackpoint, "AltitudeMeters")
+        if same_length and point["timestamp"] == eledata[index]["timestamp"]:
+            altitude.text = str(eledata[index]["elevation"])
+        else:
+            altitude.text = str(point["altitude"])
+
+        point_distance = ET.SubElement(trackpoint, "DistanceMeters")
+        point_distance.text = str(point.get("distance", 0))
+
+    return ET.tostring(tcx, encoding="UTF-8", xml_declaration=True)
+
+
+def loadactivity(archive, basename):
+    sessiondata = readjsonfromzip(archive, os.path.join(SESSION_DIRECTORY, basename))
+    gpsdata = readjsonfromzip(archive, os.path.join(GPX_DIRECTORY, basename))
+    eledata = readjsonfromzip(
+        archive, os.path.join(ELEVATION_DIRECTORY, basename), default=[]
+    )
+
+    activity = Activity()
+    activity.id = sessiondata["id"]
+    activity.datetime = datetime.datetime.fromisoformat(
+        transformdate(gpsdata[0]["timestamp"])
+    )
+    activity.distance_m = getdistance(sessiondata)
+    activity.distance_km = "%.2f" % (activity.distance_m * 0.001)
+    activity.duration_ms = sessiondata["duration"]
+
+    seconds = activity.duration_ms * 0.001
+    minutes, seconds = divmod(seconds, 60)
+    hours, minutes = divmod(minutes, 60)
+    activity.duration_display = "%02d:%02d:%02d" % (hours, minutes, seconds)
+    activity.calories = sessiondata.get("calories", 0)
+    activity.source_type = getsourcetype(archive, basename, sessiondata)
+    activity.gpx = buildgpx(activity, gpsdata, eledata)
+    activity.tcx = buildtcx(activity, gpsdata, eledata)
+    return activity
+
+
+def buildactivityindex(activities):
+    html = ET.Element("html")
+    body = ET.SubElement(html, "body")
+    table = ET.SubElement(body, "table", {"style": "border-collapse: collapse;"})
+    header_row = ET.SubElement(table, "tr")
+
+    for value in ["session id", "datetime", "distance (km)", "duration"]:
+        header = ET.SubElement(
+            header_row,
+            "th",
+            {"style": "border: 1px solid black; padding: 2px 10px;"},
+        )
+        header.text = value
+
+    for activity in iter_sorted(activities, key=lambda item: item.datetime):
+        row = ET.SubElement(table, "tr")
+        for value in getactivitysummary(activity):
+            cell = ET.SubElement(
+                row,
+                "td",
+                {"style": "border: 1px solid black; padding: 2px 10px;"},
+            )
+            cell.text = value
+
+    return ET.tostring(html, encoding="UTF-8", method="html")
+
+
+def getsessionbasenames(archive):
+    for filename in archive.namelist():
+        if os.path.dirname(filename) == GPX_DIRECTORY and filename.endswith(".json"):
+            yield os.path.basename(filename)
+
+
+def getoutputzipnames(input_path):
+    base_path = os.path.join(
+        os.path.dirname(input_path), os.path.basename(input_path).rstrip(".zip")
+    )
+    return base_path + "_GPX.zip", base_path + "_TCX.zip"
+
 
 def main():
-    
     if len(sys.argv) < 2:
-        print(usage_message)
+        print(USAGE_MESSAGE)
         sys.exit()
-        
-    gpxzipname = os.path.join(os.path.dirname(sys.argv[1]), os.path.basename(sys.argv[1]).rstrip('.zip') + '_GPX.zip')
 
-    with zipfile.ZipFile(sys.argv[1], 'r') as userzip:
-        with zipfile.ZipFile(gpxzipname, 'w', zipfile.ZIP_DEFLATED) as gpxzip:
+    gpx_zip_name, tcx_zip_name = getoutputzipnames(sys.argv[1])
 
-            print(started_message)
+    with zipfile.ZipFile(sys.argv[1], "r") as input_zip:
+        with zipfile.ZipFile(gpx_zip_name, "w", zipfile.ZIP_DEFLATED) as gpx_zip:
+            with zipfile.ZipFile(tcx_zip_name, "w", zipfile.ZIP_DEFLATED) as tcx_zip:
+                print(STARTED_MESSAGE)
 
-            activities = BST(func=(lambda a, b : a.datetime < b.datetime))
-            
-            for filename in userzip.namelist():
-                if os.path.dirname(filename) == 'Sport-sessions/GPS-data':
-                    act = getactivity(userzip, os.path.basename(filename))
-                    gpxzip.writestr(act.id + '.gpx', act.gpx)
-                    activities.insert(act)
+                activities = []
+                for basename in getsessionbasenames(input_zip):
+                    activity = loadactivity(input_zip, basename)
+                    gpx_zip.writestr(activity.id + ".gpx", activity.gpx)
+                    tcx_zip.writestr(activity.id + ".tcx", activity.tcx)
+                    activities.append(activity)
 
-            html = ET.Element('html')
-            body = ET.SubElement(html, 'body')
+                activity_index = buildactivityindex(activities)
+                gpx_zip.writestr("activities.html", activity_index)
+                tcx_zip.writestr("activities.html", activity_index)
 
-            table = ET.SubElement(body, 'table', {'style': 'border-collapse: collapse;'})
+                print(SUCCESS_MESSAGE)
 
-            header = ['session id', 'datetime', 'distance (km)', 'duration']
-            tr = ET.SubElement(table, 'tr')
 
-            for item in header:
-                th = ET.SubElement(tr, 'th', {'style': 'border: 1px solid black; padding: 2px 10px;'})
-                th.text = item
-
-            for act in traversal(activities.root):
-                row = [act.id, act.datetime.strftime('%d-%m-%Y %H:%M'), act.distance, act.duration]
-                tr = ET.SubElement(table, 'tr')
-
-                for value in row:
-                    td = ET.SubElement(tr, 'td', {'style': 'border: 1px solid black; padding: 2px 10px;'})
-                    td.text = value
-                
-            gpxzip.writestr('activities.html', ET.tostring(html, encoding="UTF-8", method="html"))
-
-            print(success_message)
-
-main()
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This updates the converter to handle newer adidas Running export formats and adds TCX output alongside GPX.

## What changed

- support GPS timestamps stored as Unix milliseconds
- handle exports without `Sport-sessions/Elevation-data`
- ignore pre-generated `.gpx` files when iterating GPS JSON payloads
- read distance from nested `features` data when it is not present at the top level
- preserve the source activity type in generated GPX files when adidas provides it
- generate a parallel `*_TCX.zip` archive for Garmin Connect imports
- update the README to document GPX and TCX output

## Why

Recent adidas exports differ from the older format this script originally expected.

Also, Garmin Connect often imports GPX activities as `Other`, while TCX carries an explicit sport field that Garmin respects for `Running` and `Biking`.

## Notes

- GPX output is still generated for compatibility
- TCX output is recommended for Garmin Connect imports when activity type matters
- activity types outside Garmin's TCX buckets still fall back to `Other`
